### PR TITLE
Revisions to Transverse Field Ising Hamiltonian builder

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -89,7 +89,8 @@ function sum_z_tup(n, tup, w)
 end
 
 """
-Function to generate a hamiltonian at a given unitless timestep, s.
+Function to build the transverse field Ising model hamiltonian at a given
+unitless timestep `s`.
 
 Arguments:
 ising_model - ising model represented as a dictionary.  The qubits
@@ -97,13 +98,9 @@ ising_model - ising model represented as a dictionary.  The qubits
               are numbers.
               For Example: im = Dict((1,) => 1, (2,) => 0.5, (1,2) => 2)
 annealing_schedule - The annealing schedule, of the form given by the struct
-s - the imaginary timestep. This should usually be in the range(0,1)
-
-Parameters:
-constant_field_x - vector of constant biases in the X basis on each qubit. Default is zeros(n)
-constant_field_z - vector of constant biases in the Z basis on each qubit. Default is zeros(n)
+s - the imaginary timestep. This should usually be in the range from 0.0-to-1.0
 """
-function build_hamiltonian(ising_model::Dict, annealing_schedule::AnnealingSchedule, s::Real; constant_field_x = nothing, constant_field_z = nothing)
+function transverse_ising_hamiltonian(ising_model::Dict, annealing_schedule::AnnealingSchedule, s::Real)
     n = _check_ising_model_ids(ising_model)
 
     x_component = sum_x(n)
@@ -112,19 +109,9 @@ function build_hamiltonian(ising_model::Dict, annealing_schedule::AnnealingSched
         z_component = z_component + sum_z_tup(n, tup, w)
     end
 
-    if constant_field_x == nothing
-        constant_field_x = zeros(n)
-    end
-
-    if constant_field_z == nothing
-        constant_field_z = zeros(n)
-    end
-
-    const_x_component = sum_x(n, constant_field_x)
-    const_z_component = sum_z(n, constant_field_z)
-
-    return annealing_schedule.A(s) * x_component + annealing_schedule.B(s) * z_component + const_x_component + const_z_component
+    return annealing_schedule.A(s) * x_component + annealing_schedule.B(s) * z_component
 end
+
 
 function integral_1_sched(a_2, a_1, a_0, s0, δ)
     #TODO: Possibly change to integrate from s0 to s1 to allow

--- a/src/simulate_de.jl
+++ b/src/simulate_de.jl
@@ -24,7 +24,18 @@ function simulate_de(ising_model, annealing_time, annealing_schedule; initial_st
         initial_state = annealing_schedule.init_default(n)
     end
 
-    H(s) = build_hamiltonian(ising_model, annealing_schedule, s, constant_field_x = constant_field_x, constant_field_z = constant_field_z)
+    if constant_field_x == nothing
+        constant_field_x = zeros(n)
+    end
+
+    if constant_field_z == nothing
+        constant_field_z = zeros(n)
+    end
+
+    const_x_component = sum_x(n, constant_field_x)
+    const_z_component = sum_z(n, constant_field_z)
+
+    H(s) = transverse_ising_hamiltonian(ising_model, annealing_schedule, s) + const_x_component + const_z_component
     schrod_eq(state, time, s) = -im * time * H(s) * state
 
     s_range = (0.0, 1.0)

--- a/test/base.jl
+++ b/test/base.jl
@@ -122,21 +122,17 @@ end
         end
     end
 
-    @testset "Hamiltonian building" begin
+    @testset "transverse ising hamiltonian building" begin
         ising_model = Dict((1,) => 1)
         annealing_schedule = AS_CIRCULAR
 
-        H_no_const_fields_0 = build_hamiltonian(ising_model, annealing_schedule, 0)
-        H_no_const_fields_1 = build_hamiltonian(ising_model, annealing_schedule, 1)
+        H_00 = transverse_ising_hamiltonian(ising_model, annealing_schedule, 0.0)
+        H_05 = transverse_ising_hamiltonian(ising_model, annealing_schedule, 0.5)
+        H_10 = transverse_ising_hamiltonian(ising_model, annealing_schedule, 1.0)
 
-        @test isapprox(H_no_const_fields_0, [0 1; 1 0])
-        @test isapprox(H_no_const_fields_1, [1 0; 0 -1])
-
-        H_const_fields_0 = build_hamiltonian(ising_model, annealing_schedule, 0, constant_field_x = [1], constant_field_z = [1])
-        H_const_fields_1 = build_hamiltonian(ising_model, annealing_schedule, 1, constant_field_x = [1], constant_field_z = [1])
-
-        @test isapprox(H_const_fields_0, [1 2; 2 -1])
-        @test isapprox(H_const_fields_1, [2 1; 1 -2])
+        @test isapprox(H_00, [0 1; 1 0])
+        @test isapprox(H_05, [1/sqrt(2) 1/sqrt(2); 1/sqrt(2) -1/sqrt(2)])
+        @test isapprox(H_10, [1 0; 0 -1])
     end
 end
 

--- a/test/simulate.jl
+++ b/test/simulate.jl
@@ -36,7 +36,7 @@ single_spin_analytic_prob = real(tr(single_spin_analytic_ρ * [0 0; 0 1]))
         @test isapprox(ρ_target, ρ)
     end
 
-    @testset "1 qubit, franctional field value" begin
+    @testset "1 qubit, fractional field value" begin
         ρ_target = [0.420186+0.0im -0.409634+0.275372im; -0.409634-0.275372im 0.579814+2.77556e-17im]
         ρ = simulate(Dict((1,) => 0.5), 1.0, AS_CIRCULAR, 100)
 
@@ -47,6 +47,14 @@ single_spin_analytic_prob = real(tr(single_spin_analytic_ρ * [0 0; 0 1]))
     @testset "1 qubit, field value above 1.0" begin
         ρ_target = [0.291065-2.77556e-17im 0.114524+0.43958im; 0.114524-0.43958im 0.708935+5.55112e-17im]
         ρ = simulate(Dict((1,) => 1.5), 1.0, AS_CIRCULAR, 100)
+
+        # NOTE, atol required due to too few digits in target
+        @test isapprox(ρ_target, ρ, atol=1e-6)
+    end
+
+    @testset "1 qubit, function schedule, constant terms" begin
+        ρ_target = [0.0578906+1.38778e-17im -0.165069-0.165202im; -0.165069+0.165202im 0.942109+0.0im]
+        ρ = simulate(single_spin_model, 1.0, AS_CIRCULAR, constant_field_x = [1], constant_field_z = [1])
 
         # NOTE, atol required due to too few digits in target
         @test isapprox(ρ_target, ρ, atol=1e-6)
@@ -377,6 +385,14 @@ end
         ρ = simulate_de(single_spin_model, 1.0, AS_CIRCULAR)
 
         @test isapprox(single_spin_analytic_ρ, ρ)
+    end
+
+    @testset "1 qubit, function schedule, constant terms" begin
+        ρ = simulate(single_spin_model, 1.0, AS_CIRCULAR, constant_field_x = [1], constant_field_z = [1])
+        ρ_de = simulate_de(single_spin_model, 1.0, AS_CIRCULAR, constant_field_x = [1], constant_field_z = [1])
+
+        @test isapprox(ρ, ρ_de, atol=1e-7)
+        @test !isapprox(ρ, ρ_de, atol=1e-8)
     end
 
     @testset "1 qubit, csv schedule, analytical solution" begin


### PR DESCRIPTION
@zmorrell, this is what I had in mind.  I think most users of this feature will not need to the constant terms, so we can leave these out.  Also gave the function a more descriptive name with the idea of supporting different Hamiltonians down the road.  I also added some new tests targeting the `constant_field` capability more specifically, so that we won't regress on the bug you found. 