### PR TITLE
Make magnus API more consistent

### DIFF
--- a/test/magnus.jl
+++ b/test/magnus.jl
@@ -57,8 +57,7 @@
             aqc[3] * x_component + bqc[3] * z_component,
         ]
 
-        Ω_list_tmp = QuantumAnnealing._magnus_generator(H, order)
-        Ω_list2 = [QuantumAnnealing._hamiltonian_eval(δs, Ωi) for Ωi in Ω_list_tmp]
+        Ω_list2 = QuantumAnnealing._magnus_generator(δs, H, order)
 
         for i in 1:order
             @test isapprox(Ω_list1[i], Ω_list2[i])


### PR DESCRIPTION
move `_hamiltonian_eval` inside of `_magnus_generator` so that its output values are similar to `_Ω_list`.