### PR TITLE
Add boltzmann sampling functionality, closes #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ QuantumAnnealing.jl Change Log
 ==============================
 
 ### Staged
-- nothing
+- Add Boltzmann sampling
 
 ### v0.2.0
 - Add a generic Magnus expansion solver for any order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ QuantumAnnealing.jl Change Log
 ==============================
 
 ### Staged
-- Add Boltzmann sampling
+- Add Gibbs distribution
 
 ### v0.2.0
 - Add a generic Magnus expansion solver for any order

--- a/src/base.jl
+++ b/src/base.jl
@@ -166,7 +166,7 @@ function print_z_state_probabilities(density::Matrix; limit=50, sort=false)
     end
 end
 
-function sample_boltzmann(H::Function, s::Real; β=1)
+function z_probabilities_boltzmann(H::Function, s::Real, β::Real)
     tr(A) = sum([A[i,i] for i=1:(size(A)[1])])
     exp_ham = exp(-β * Matrix(H(s)))
     exp_ham = exp_ham ./ tr(exp_ham)

--- a/src/base.jl
+++ b/src/base.jl
@@ -165,3 +165,10 @@ function print_z_state_probabilities(density::Matrix; limit=50, sort=false)
         end
     end
 end
+
+function sample_boltzmann(H::Function, s::Real; β=1)
+    tr(A) = sum([A[i,i] for i=1:(size(A)[1])])
+    exp_ham = exp(-β * Matrix(H(s)))
+    exp_ham = exp_ham ./ tr(exp_ham)
+    return [real(exp_ham[i,i]) for i = 1:(size(exp_ham)[1])]
+end

--- a/src/base.jl
+++ b/src/base.jl
@@ -166,9 +166,9 @@ function print_z_state_probabilities(density::Matrix; limit=50, sort=false)
     end
 end
 
-function z_probabilities_boltzmann(H::Function, s::Real, β::Real)
+function distribution_gibbs(H::Function, s::Real, β::Real)
     tr(A) = sum([A[i,i] for i=1:(size(A)[1])])
     exp_ham = exp(-β * Matrix(H(s)))
     exp_ham = exp_ham ./ tr(exp_ham)
-    return [real(exp_ham[i,i]) for i = 1:(size(exp_ham)[1])]
+    return exp_ham
 end

--- a/test/base.jl
+++ b/test/base.jl
@@ -162,8 +162,8 @@ end
     end
 
     @testset "boltzmann sampling, 1 qubit" begin
-        @test isapprox(sample_boltzmann(one_spin_H, 0), [0.5, 0.5])
-        @test isapprox(sample_boltzmann(one_spin_H, 1, β=100), [0, 1])
+        @test isapprox(z_probabilities_boltzmann(one_spin_H, 0, 1), [0.5, 0.5])
+        @test isapprox(z_probabilities_boltzmann(one_spin_H, 1, 100), [0, 1])
     end
 end
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -161,6 +161,10 @@ end
         @test isapprox(H_10, [2.0 0.0 0.0 0.0; 0.0 -2.0 0.0 0.0; 0.0 0.0 -2.0 0.0; 0.0 0.0 0.0 2.0])
     end
 
+    @testset "boltzmann sampling, 1 qubit" begin
+        @test isapprox(sample_boltzmann(one_spin_H, 0), [0.5, 0.5])
+        @test isapprox(sample_boltzmann(one_spin_H, 1, β=100), [0, 1])
+    end
 end
 
 
@@ -211,6 +215,5 @@ end
     end
 
 end
-
 
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -162,8 +162,8 @@ end
     end
 
     @testset "boltzmann sampling, 1 qubit" begin
-        @test isapprox(z_probabilities_boltzmann(one_spin_H, 0, 1), [0.5, 0.5])
-        @test isapprox(z_probabilities_boltzmann(one_spin_H, 1, 100), [0, 1])
+        @test isapprox(z_measure_probabilities(distribution_gibbs(one_spin_H, 0, 1)), [0.5, 0.5])
+        @test isapprox(z_measure_probabilities(distribution_gibbs(one_spin_H, 1, 100)), [0, 1])
     end
 end
 


### PR DESCRIPTION
@ccoffrin The testing on this is rather rudimentary, but I couldn't figure out a much better way to do it, since theoretically boltzmann sampling of the classical and quantum hamiltonian would give the same results under the tests which I added.  I think it is best to just double check that the code is correct, which should be fine since it is only 4 lines or so.