### PR TITLE
Add initial h_gain_schedule implementation

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -11,13 +11,20 @@ struct AnnealingSchedule
     A::Function
     B::Function
     init_default::Function
+    h_gain_schedule::Function
 end
 
 """
 A short hand AnnealingSchedule constructor that uses the initial_state_default,
 which is the most common case for the conventions of this implementation.
 """
-AnnealingSchedule(A,B) = AnnealingSchedule(A, B, initial_state_default)
+AnnealingSchedule(A,B) = AnnealingSchedule(A, B, initial_state_default, one)
+
+"""
+A short hand AnnealingSchedule constructor that uses the Base.one function for the
+annealing schedule, but allows for a different inital state.
+"""
+AnnealingSchedule(A,B,init_default) = AnnealingSchedule(A, B, init_default, one)
 
 #predefining Pauli Matrices
 const _IMAT = SparseArrays.sparse([1,2], [1,2], [1.0+0im;1.0+0im])


### PR DESCRIPTION
@ccoffrin 
This is an initial attempt at the h-gains schedule implementation.  I still need to add tests and fully verify that it is working, but as it stands it does not break anything that already works.  Because of the way that the unwrapped magnus expansion is currently implemented, it would be very difficult to break h and J terms into their own terms, so for each time step, I assume that the h_gain_schedule over the step is well approximated by the average of the starting and ending hgs values.

This approach may introduce some overhead because it reconstructs the z_component of the hamiltonian on every iteration, but since it is sparse, this overhead should be insignificant compared to the matrix exponentiation, so I don't expect that it will hamper performance too much.

Does this all seem like a reasonable way to implement this new feature