### PR TITLE
Tolerance parameter to compute_ising_energy_levels() function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/ising.jl
+++ b/src/ising.jl
@@ -35,19 +35,24 @@ end
 """
 given an Ising model computes a mapping from energy values to collections of state integers
 """
-function compute_ising_energy_levels(ising_model::Dict)
+function compute_ising_energy_levels(ising_model::Dict; tol=1e-6)
     state_energies = compute_ising_state_energies(ising_model)
-
     energy_levels = Dict{Float64,Set{Int}}()
+
     for (state_id, energy) in state_energies
-        if !haskey(energy_levels, energy)
-            energy_levels[energy] = Set{Int}()
+        found = false
+        for key in collect(keys(energy_levels))
+            if abs(energy - key) < tol
+                push!(energy_levels[key], state_id) 
+                found = true
+                break
+            end 
+        end 
+        if !found
+            energy_levels[energy] = Set([state_id])
         end
-        push!(energy_levels[energy], state_id)
     end
-
     energies = sort(collect(keys(energy_levels)))
-
     return [(energy=e, states=energy_levels[e]) for e in energies]
 end
 

--- a/src/ising.jl
+++ b/src/ising.jl
@@ -35,22 +35,17 @@ end
 """
 given an Ising model computes a mapping from energy values to collections of state integers
 """
-function compute_ising_energy_levels(ising_model::Dict; tol=1e-6)
+function compute_ising_energy_levels(ising_model::Dict; sigdigits=20, base=2)
     state_energies = compute_ising_state_energies(ising_model)
     energy_levels = Dict{Float64,Set{Int}}()
-
+    
     for (state_id, energy) in state_energies
-        found = false
-        for key in collect(keys(energy_levels))
-            if abs(energy - key) < tol
-                push!(energy_levels[key], state_id) 
-                found = true
-                break
-            end 
-        end 
-        if !found
-            energy_levels[energy] = Set([state_id])
+        energy = round(energy, sigdigits=sigdigits, base=base)
+
+        if !haskey(energy_levels, energy)
+            energy_levels[energy] = Set{Int}()
         end
+        push!(energy_levels[energy], state_id)
     end
     energies = sort(collect(keys(energy_levels)))
     return [(energy=e, states=energy_levels[e]) for e in energies]


### PR DESCRIPTION
Addresses Issue #54 which was due to having numerical precision errors in ground state filtering. This PR modifies the `compute_ising_energy_levels()` function to accept an optional tolerance parameter (`tol`, defaulting to `1e-6`). Instead of grouping states by exact equality of their computed energy values (as `Float64`), we now group energies that differ by less than the specified tolerance. 

